### PR TITLE
Ajout des tarifs fixes quotidiens

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Copy the `tarif_edf` folder from latest release to the `custom_components` folde
 |--------|-------------|------|
 | `sensor.tarif_base_fixe_ttc` | Fixed rate (incl. taxes) | EUR/an |
 | `sensor.tarif_base_fixe_ht` | Fixed rate (excl. taxes) | EUR/an |
+| `sensor.tarif_base_fixe_ttc_jour` | Daily fixed rate (incl. taxes) | EUR/jour |
+| `sensor.tarif_base_fixe_ht_jour` | Daily fixed rate (excl. taxes) | EUR/jour |
 | `sensor.tarif_base_variable_ttc` | Variable rate (incl. taxes) | EUR/kWh |
 | `sensor.tarif_base_variable_ht` | Variable rate (excl. taxes) | EUR/kWh |
 
@@ -36,6 +38,8 @@ Copy the `tarif_edf` folder from latest release to the `custom_components` folde
 |--------|-------------|------|
 | `sensor.tarif_hphc_fixe_ttc` | Fixed rate (incl. taxes) | EUR/an |
 | `sensor.tarif_hphc_fixe_ht` | Fixed rate (excl. taxes) | EUR/an |
+| `sensor.tarif_hphc_fixe_ttc_jour` | Daily fixed rate (incl. taxes) | EUR/jour |
+| `sensor.tarif_hphc_fixe_ht_jour` | Daily fixed rate (excl. taxes) | EUR/jour |
 | `sensor.tarif_hphc_heures_creuses_ttc` | Off-peak hours rate (incl. taxes) | EUR/kWh |
 | `sensor.tarif_hphc_heures_creuses_ht` | Off-peak hours rate (excl. taxes) | EUR/kWh |
 | `sensor.tarif_hphc_heures_pleines_ttc` | Peak hours rate (incl. taxes) | EUR/kWh |
@@ -46,6 +50,8 @@ Copy the `tarif_edf` folder from latest release to the `custom_components` folde
 |--------|-------------|------|
 | `sensor.tarif_tempo_fixe_ttc` | Fixed rate (incl. taxes) | EUR/an |
 | `sensor.tarif_tempo_fixe_ht` | Fixed rate (excl. taxes) | EUR/an |
+| `sensor.tarif_tempo_fixe_ttc_jour` | Daily fixed rate (incl. taxes) | EUR/jour |
+| `sensor.tarif_tempo_fixe_ht_jour` | Daily fixed rate (excl. taxes) | EUR/jour |
 | `sensor.tarif_tempo_couleur` | Current Tempo color | - |
 | `sensor.tarif_tempo_couleur_hier` | Yesterday's Tempo color | - |
 | `sensor.tarif_tempo_couleur_aujourd_hui` | Today's Tempo color | - |

--- a/custom_components/tarif_edf/coordinator.py
+++ b/custom_components/tarif_edf/coordinator.py
@@ -30,6 +30,8 @@ from .const import (
     TEMPO_OFFPEAK_HOURS
 )
 
+from calendar import monthrange
+
 _LOGGER = logging.getLogger(__name__)
 
 def get_remote_file(url: str):
@@ -86,6 +88,12 @@ class TarifEdfDataUpdateCoordinator(TimestampDataUpdateCoordinator):
 
         return response_json
 
+    def get_daily_price(price):
+        year = datetime.now().year
+        month = datetime.now().month
+        nb_days = monthrange(year, month)
+        return price/12/nb_days
+
     async def _async_update_data(self) -> dict[Platform, dict[str, Any]]:
         """Get the latest data from Tarif EDF and updates the state."""
         data = self.config_entry.data
@@ -123,11 +131,15 @@ class TarifEdfDataUpdateCoordinator(TimestampDataUpdateCoordinator):
                     if data['contract_type'] == CONTRACT_TYPE_BASE:
                         self.data['base_fixe_ttc'] = float(row[4].replace(",", "." ))
                         self.data['base_fixe_ht'] = float(row[3].replace(",", "." ))
+                        self.data['base_fixe_ttc_jour'] = self.get_daily_price(self.data['base_fixe_ttc'])
+                        self.data['base_fixe_ht_jour'] = self.get_daily_price(self.data['base_fixe_ht'])
                         self.data['base_variable_ttc'] = float(row[6].replace(",", "." ))
                         self.data['base_variable_ht'] = float(row[5].replace(",", "." ))
                     elif data['contract_type'] == CONTRACT_TYPE_HPHC:
                         self.data['hphc_fixe_ttc'] = float(row[4].replace(",", "." ))
                         self.data['hphc_fixe_ht'] = float(row[3].replace(",", "." ))
+                        self.data['hphc_fixe_ttc_jour'] = self.get_daily_price(self.data['hphc_fixe_ttc'])
+                        self.data['hphc_fixe_ht_jour'] = self.get_daily_price(self.data['hphc_fixe_ht'])
                         self.data['hphc_variable_hc_ttc'] = float(row[6].replace(",", "." ))
                         self.data['hphc_variable_hc_ht'] = float(row[5].replace(",", "." ))
                         self.data['hphc_variable_hp_ttc'] = float(row[8].replace(",", "." ))
@@ -135,6 +147,8 @@ class TarifEdfDataUpdateCoordinator(TimestampDataUpdateCoordinator):
                     elif data['contract_type'] == CONTRACT_TYPE_TEMPO:
                         self.data['tempo_fixe_ttc'] = float(row[4].replace(",", "." ))
                         self.data['tempo_fixe_ht'] = float(row[3].replace(",", "." ))
+                        self.data['tempo_fixe_ttc_jour'] = self.get_daily_price(self.data['tempo_fixe_ttc'])
+                        self.data['tempo_fixe_ht_jour'] = self.get_daily_price(self.data['tempo_fixe_ht'])
                         self.data['tempo_variable_hc_bleu_ttc'] = float(row[6].replace(",", "." ))
                         self.data['tempo_variable_hc_bleu_ht'] = float(row[5].replace(",", "." ))
                         self.data['tempo_variable_hp_bleu_ttc'] = float(row[8].replace(",", "." ))

--- a/custom_components/tarif_edf/coordinator.py
+++ b/custom_components/tarif_edf/coordinator.py
@@ -88,11 +88,12 @@ class TarifEdfDataUpdateCoordinator(TimestampDataUpdateCoordinator):
 
         return response_json
 
+    @staticmethod
     def get_daily_price(price):
         year = datetime.now().year
         month = datetime.now().month
-        nb_days = monthrange(year, month)
-        return price/12/nb_days
+        nb_days = monthrange(year, month)[1]
+        return round(price/12/nb_days, 2)
 
     async def _async_update_data(self) -> dict[Platform, dict[str, Any]]:
         """Get the latest data from Tarif EDF and updates the state."""

--- a/custom_components/tarif_edf/sensor.py
+++ b/custom_components/tarif_edf/sensor.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
 
-
 from .coordinator import TarifEdfDataUpdateCoordinator
 
 from .const import (
@@ -35,15 +34,19 @@ async def async_setup_entry(
 
     if coordinator.data['contract_type'] == CONTRACT_TYPE_BASE:
         sensors.extend([
-            TarifEdfSensor(coordinator, 'base_fixe_ttc', 'Tarif Base Fixe TTC', 'EUR/an'),
-            TarifEdfSensor(coordinator, 'base_fixe_ht', 'Tarif Base Fixe HT', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'base_fixe_ttc', 'Tarif Base Fixe TTC par an', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'base_fixe_ht', 'Tarif Base Fixe HT par an', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'base_fixe_ttc_jour', 'Tarif Base Fixe TTC par jour', 'EUR/jour'),
+            TarifEdfSensor(coordinator, 'base_fixe_ht_jour', 'Tarif Base Fixe HT par jour', 'EUR/jour'),
             TarifEdfSensor(coordinator, 'base_variable_ttc', 'Tarif Base Variable TTC', 'EUR/kWh'),
             TarifEdfSensor(coordinator, 'base_variable_ht', 'Tarif Base Variable HT', 'EUR/kWh'),
         ])
     elif coordinator.data['contract_type'] == CONTRACT_TYPE_HPHC:
         sensors.extend([
-            TarifEdfSensor(coordinator, 'hphc_fixe_ttc', 'Tarif HPHC Fixe TTC', 'EUR/an'),
-            TarifEdfSensor(coordinator, 'hphc_fixe_ht', 'Tarif HPHC Fixe HT', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'hphc_fixe_ttc', 'Tarif HPHC Fixe TTC par an', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'hphc_fixe_ht', 'Tarif HPHC Fixe HT par an', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'hphc_fixe_ttc_jour', 'Tarif HPHC Fixe TTC par jour', 'EUR/jour'),
+            TarifEdfSensor(coordinator, 'hphc_fixe_ht_jour', 'Tarif HPHC Fixe HT par jour', 'EUR/jour'),
             TarifEdfSensor(coordinator, 'hphc_variable_hc_ttc', 'Tarif HPHC Heures Creuses TTC', 'EUR/kWh'),
             TarifEdfSensor(coordinator, 'hphc_variable_hc_ht', 'Tarif HPHC Heures Creuses HT', 'EUR/kWh'),
             TarifEdfSensor(coordinator, 'hphc_variable_hp_ttc', 'Tarif HPHC Heures Pleines TTC', 'EUR/kWh'),
@@ -51,8 +54,10 @@ async def async_setup_entry(
         ])
     elif coordinator.data['contract_type'] == CONTRACT_TYPE_TEMPO:
         sensors.extend([
-            TarifEdfSensor(coordinator, 'tempo_fixe_ttc', 'Tarif Tempo Fixe TTC', 'EUR/an'),
-            TarifEdfSensor(coordinator, 'tempo_fixe_ht', 'Tarif Tempo Fixe HT', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'tempo_fixe_ttc', 'Tarif Tempo Fixe TTC par an', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'tempo_fixe_ht', 'Tarif Tempo Fixe HT par an', 'EUR/an'),
+            TarifEdfSensor(coordinator, 'tempo_fixe_ttc_jour', 'Tarif Tempo Fixe TTC par jour', 'EUR/jour'),
+            TarifEdfSensor(coordinator, 'tempo_fixe_ht_jour', 'Tarif Tempo Fixe HT par jour', 'EUR/jour'),
             TarifEdfSensor(coordinator, 'tempo_variable_hc_bleu_ttc', 'Tarif Bleu Tempo Heures Creuses TTC', 'EUR/kWh'),
             TarifEdfSensor(coordinator, 'tempo_variable_hc_bleu_ht', 'Tarif Bleu Tempo Heures Creuses HT', 'EUR/kWh'),
             TarifEdfSensor(coordinator, 'tempo_variable_hp_bleu_ttc', 'Tarif Bleu Tempo Heures Pleines TTC', 'EUR/kWh'),


### PR DESCRIPTION
Ajout de deux sensors qui exposent le tarif de l'abonnement quotidien (TTC et HT) sur la base du tarif de l'abonnement annuel.
![{B0FAC71B-EE11-42BA-BEEC-90C1AE55E5F5}](https://github.com/user-attachments/assets/8c51785a-790a-4571-9859-981a34ad525b)

Use case : j'utilise la valeur TTC pour faire apparaitre l'abonnement dans le dashboard Energie :
![{36632962-4FA9-44A4-9B2B-2AD8E88332E9}](https://github.com/user-attachments/assets/09605fc4-9971-44cc-b321-3049ce08d144)
